### PR TITLE
Add side-by-side view toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,12 @@ def compare():
     base_html = mammoth.convert_to_html(io.BytesIO(base_file.read())).value
     new_html = mammoth.convert_to_html(io.BytesIO(new_file.read())).value
     comparison_html = render_html_diff(base_html, new_html)
-    return render_template('result.html', comparison_html=comparison_html)
+    return render_template(
+        'result.html',
+        comparison_html=comparison_html,
+        base_html=base_html,
+        new_html=new_html,
+    )
 
 # --- REPLACE YOUR OLD EXPORT FUNCTION WITH THIS ONE ---
 @app.route('/export', methods=['POST'])

--- a/templates/result.html
+++ b/templates/result.html
@@ -28,6 +28,10 @@
         .btn.secondary:hover { background-color: #5a6268; }
         .btn.active { background-color: #28a745; color: white; border-color: #28a745; }
 
+        /* --- Side-by-Side Layout --- */
+        #side-by-side { display: none; gap: 20px; margin-top: 20px; }
+        #side-by-side .side-pane { flex: 1; border: 1px solid #dddfe2; padding: 10px; overflow-y: auto; max-height: 70vh; }
+
         /* --- CSS for View Filtering --- */
         .document-content.show-original ins { display: none; }
         .document-content.show-final del { display: none; }
@@ -54,20 +58,35 @@
                 <button id="filter-final" class="btn">Final (V2)</button>
             </div>
             <div class="action-buttons">
+                <button id="toggle-view-btn" class="btn secondary">Side-by-Side View</button>
                 <button id="edit-btn" class="btn secondary">Edit</button>
                 <button id="save-btn" class="btn primary">Save & Export as DOCX</button>
             </div>
         </div>
-        
+
         <div id="document-content" class="document-content">
             <!-- The 'safe' filter renders the HTML from the server -->
             {{ comparison_html | safe }}
+        </div>
+
+        <div id="side-by-side">
+            <div class="side-pane" id="base-pane">
+                {{ base_html | safe }}
+            </div>
+            <div class="side-pane" id="diff-pane">
+                {{ comparison_html | safe }}
+            </div>
+            <div class="side-pane" id="new-pane">
+                {{ new_html | safe }}
+            </div>
         </div>
     </div>
 
     <!-- === NEW JAVASCRIPT SECTION === -->
     <script>
         const docContent = document.getElementById('document-content');
+        const sideBySide = document.getElementById('side-by-side');
+        const toggleViewBtn = document.getElementById('toggle-view-btn');
         const editBtn = document.getElementById('edit-btn');
         const saveBtn = document.getElementById('save-btn');
 
@@ -87,6 +106,20 @@
                     docContent.classList.add('show-final');
                 }
             });
+        });
+
+        // --- Side-by-Side Toggle Logic ---
+        toggleViewBtn.addEventListener('click', function() {
+            const showingSideBySide = sideBySide.style.display === 'flex';
+            if (showingSideBySide) {
+                sideBySide.style.display = 'none';
+                docContent.style.display = 'block';
+                this.textContent = 'Side-by-Side View';
+            } else {
+                sideBySide.style.display = 'flex';
+                docContent.style.display = 'none';
+                this.textContent = 'Overlay View';
+            }
         });
 
         // --- Feature 2: Live Editing Logic ---

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,33 @@
+import io
+import os
+import sys
+from docx import Document
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app
+
+
+def create_docx(text: str) -> bytes:
+    document = Document()
+    document.add_paragraph(text)
+    buffer = io.BytesIO()
+    document.save(buffer)
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def test_compare_route_returns_all_html():
+    client = app.test_client()
+    base_content = create_docx("Base text")
+    new_content = create_docx("New text")
+    data = {
+        'base_file': (io.BytesIO(base_content), 'base.docx'),
+        'new_file': (io.BytesIO(new_content), 'new.docx'),
+    }
+    response = client.post('/compare', data=data, content_type='multipart/form-data')
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'Base text' in html
+    assert 'New text' in html
+    # side-by-side container should be present
+    assert 'side-by-side' in html


### PR DESCRIPTION
## Summary
- allow `/compare` to render base and new HTML
- add button and containers for side-by-side comparison
- add JS to toggle overlay vs. side-by-side modes
- add unit test for the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a710b6108832bb83c0a19e71b2b1d